### PR TITLE
Implementing rootless steamcmd execution with steam user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,19 +38,13 @@ RUN mkdir /app/steamcmd /app/sonsoftheforest /app/wine \
     && apt-get install -y --no-install-recommends winehq-stable \
     # Clean up
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Create steam user
-RUN useradd --no-create-home --shell /bin/false steam
-
-# Change ownership
-RUN chown -R steam:steam /app
-
-# Change permissions
-RUN chmod -R 750 /app
-
-# Copy main.sh script
-COPY --chown=steam:steam --chmod=550 main.sh /app/
+    && rm -rf /var/lib/apt/lists/* \
+    # Create steam user
+    useradd --no-create-home --shell /bin/false steam \
+    # Change ownership
+    chown -R steam:steam /app \
+    # Change permissions
+    chmod -R 750 /app
 
 # Switch to steam user
 USER steam
@@ -60,5 +54,8 @@ RUN ["/bin/bash", "-c", "set -o pipefail && wget -qO- https://steamcdn-a.akamaih
 
 # Download Sons of the Forest dedicated server
 RUN /app/steamcmd/steamcmd.sh +@sSteamCmdForcePlatformType windows +force_install_dir /app/sonsoftheforest +login anonymous +app_update 2465200 validate +quit
+
+# Copy main.sh script
+COPY --chown=steam:steam --chmod=550 main.sh /app/
 
 CMD ["/bin/bash", "-c", "/app/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,11 @@ RUN mkdir /app/steamcmd /app/sonsoftheforest /app/wine \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     # Create steam user
-    useradd --no-create-home --shell /bin/false steam \
+    && useradd --no-create-home --shell /bin/false steam \
     # Change ownership
-    chown -R steam:steam /app \
+    && chown -R steam:steam /app \
     # Change permissions
-    chmod -R 750 /app
+    && chmod -R 750 /app
 
 # Switch to steam user
 USER steam

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     container_name: sotf-server
     image: chemineer/sons-of-the-forest-dedicated:latest
     #build: .
-    network_mode: "host"
-    restart: always
     init: true
     ports:
       - "8766:8766/udp" # Game port
@@ -12,3 +10,4 @@ services:
       - "9700:9700/udp" # Blob sync port
     volumes:
       - ./userdata:/app/sonsoftheforest/userdata
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,9 @@ services:
     network_mode: "host"
     restart: always
     init: true
+    ports:
+      - "8766:8766/udp" # Game port
+      - "27016:27016/udp" # Query port
+      - "9700:9700/udp" # Blob sync port
     volumes:
       - ./userdata:/app/sonsoftheforest/userdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     container_name: sotf-server
     image: chemineer/sons-of-the-forest-dedicated:latest
     #build: .
+    restart: always
     init: true
     ports:
       - "8766:8766/udp" # Game port
@@ -10,4 +11,3 @@ services:
       - "9700:9700/udp" # Blob sync port
     volumes:
       - ./userdata:/app/sonsoftheforest/userdata
-    restart: always

--- a/main.sh
+++ b/main.sh
@@ -20,7 +20,7 @@ function startXvfb {
     if ! isXvfbRunning; then
         rm -f /tmp/.X1-lock
         echo "Starting Xvfb"
-        Xvfb :1 -screen 0 1024x768x24 &
+        Xvfb :1 -screen 0 1024x768x24 -nolisten linux &
         echo "Sleeping for a few seconds"
         sleep 10
         echo "Rebooting wine"

--- a/main.sh
+++ b/main.sh
@@ -20,7 +20,7 @@ function startXvfb {
     if ! isXvfbRunning; then
         rm -f /tmp/.X1-lock
         echo "Starting Xvfb"
-        Xvfb :1 -screen 0 1024x768x24 -nolisten linux &
+        Xvfb :1 -screen 0 1024x768x24 -nolisten unix &
         echo "Sleeping for a few seconds"
         sleep 10
         echo "Rebooting wine"


### PR DESCRIPTION
Hey,

Thanks for your sharing. Here is the implementation of rootless steamcmd execution with steam user creation.

To do so, I had to create the steam user, define the appropriate files owner and permissions, and also setup the `HOME` environment variable for steam to be able to write logs.

`network_mode: "host"` is a security issue because it removes the network isolation provided by Docker’s default bridge network. It has been replaced by the ports field in `docker-compose.yml`

PS : why `init: true` ?